### PR TITLE
Enable region affinity scheduler

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -735,6 +735,20 @@ public class JobManagerOptions {
                                                     "FLINK-33977"))
                                     .build());
 
+    @Experimental
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Boolean> REGION_AWARE_SCHEDULER =
+            key("jobmanager.scheduler.region-aware")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enable pipeline region affinity when assigning slots. "
+                                    + "If enabled, tasks belonging to the same pipeline region are "
+                                    + "co-located on the same set of TaskManagers whenever possible.");
+
     /**
      * Config parameter controlling whether partitions should already be released during the job
      * execution.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/RegionPackingSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/RegionPackingSlotSelectionStrategy.java
@@ -1,0 +1,56 @@
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.slotpool.FreeSlotTracker;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Slot selection strategy that packs slots onto as few TaskManagers as possible.
+ */
+class RegionPackingSlotSelectionStrategy extends LocationPreferenceSlotSelectionStrategy {
+
+    @Nonnull
+    @Override
+    protected Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
+            @Nonnull FreeSlotTracker freeSlotTracker, @Nonnull ResourceProfile resourceProfile) {
+        Map<ResourceID, Integer> freePerTm = new HashMap<>();
+        for (PhysicalSlot slot : freeSlotTracker.getFreeSlotsInformation()) {
+            ResourceID tm = slot.getTaskManagerLocation().getResourceID();
+            if (slot.getResourceProfile().isMatching(resourceProfile)) {
+                freePerTm.merge(tm, 1, Integer::sum);
+            }
+        }
+        SlotInfo bestCandidate = null;
+        int bestCount = -1;
+        for (AllocationID id : freeSlotTracker.getAvailableSlots()) {
+            SlotInfo info = freeSlotTracker.getSlotInfo(id);
+            if (!info.getResourceProfile().isMatching(resourceProfile)) {
+                continue;
+            }
+            ResourceID tm = info.getTaskManagerLocation().getResourceID();
+            int count = freePerTm.getOrDefault(tm, 0);
+            if (count > bestCount) {
+                bestCount = count;
+                bestCandidate = info;
+            }
+        }
+        return bestCandidate == null
+                ? Optional.empty()
+                : Optional.of(SlotInfoAndLocality.of(bestCandidate, Locality.UNCONSTRAINED));
+    }
+
+    @Override
+    protected double calculateCandidateScore(
+            int localWeigh, int hostLocalWeigh, java.util.function.Supplier<Double> taskExecutorUtilizationSupplier) {
+        return -taskExecutorUtilizationSupplier.get();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/RegionSlotSharingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/RegionSlotSharingStrategy.java
@@ -1,0 +1,58 @@
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingPipelinedRegion;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Slot sharing strategy that groups vertices by their pipeline region.
+ * Each region will share slots so that all contained vertices prefer to run
+ * on the same TaskManager.
+ */
+@Experimental
+class RegionSlotSharingStrategy extends AbstractSlotSharingStrategy {
+
+    RegionSlotSharingStrategy(
+            SchedulingTopology topology,
+            Set<SlotSharingGroup> logicalSlotSharingGroups,
+            Set<CoLocationGroup> coLocationGroups) {
+        super(topology, logicalSlotSharingGroups, coLocationGroups);
+    }
+
+    static class Factory implements SlotSharingStrategy.Factory {
+        @Override
+        public SlotSharingStrategy create(
+                SchedulingTopology topology,
+                Set<SlotSharingGroup> logicalSlotSharingGroups,
+                Set<CoLocationGroup> coLocationGroups) {
+            return new RegionSlotSharingStrategy(topology, logicalSlotSharingGroups, coLocationGroups);
+        }
+    }
+
+    @Override
+    protected Map<ExecutionVertexID, ExecutionSlotSharingGroup> computeExecutionSlotSharingGroups(
+            SchedulingTopology schedulingTopology) {
+        Map<ExecutionVertexID, ExecutionSlotSharingGroup> result = new HashMap<>();
+        for (SchedulingPipelinedRegion region : schedulingTopology.getAllPipelinedRegions()) {
+            Map<Integer, ExecutionSlotSharingGroup> groupsByIndex = new HashMap<>();
+            for (SchedulingExecutionVertex vertex : region.getVertices()) {
+                int subtask = vertex.getId().getSubtaskIndex();
+                ExecutionSlotSharingGroup group =
+                        groupsByIndex.computeIfAbsent(
+                                subtask,
+                                i -> new ExecutionSlotSharingGroup(new SlotSharingGroup()));
+                group.addVertex(vertex.getId());
+                result.put(vertex.getId(), group);
+            }
+        }
+        return result;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtils.java
@@ -22,6 +22,8 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.jobmaster.slotpool.RegionPackingSlotSelectionStrategy;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.PreviousAllocationSlotSelectionStrategy;
@@ -44,10 +46,14 @@ public class SlotSelectionStrategyUtils {
 
         final SlotSelectionStrategy locationPreferenceSlotSelectionStrategy;
 
-        locationPreferenceSlotSelectionStrategy =
-                taskManagerLoadBalanceMode == TaskManagerLoadBalanceMode.SLOTS
-                        ? LocationPreferenceSlotSelectionStrategy.createEvenlySpreadOut()
-                        : LocationPreferenceSlotSelectionStrategy.createDefault();
+        if (configuration.get(JobManagerOptions.REGION_AWARE_SCHEDULER)) {
+            locationPreferenceSlotSelectionStrategy = new RegionPackingSlotSelectionStrategy();
+        } else {
+            locationPreferenceSlotSelectionStrategy =
+                    taskManagerLoadBalanceMode == TaskManagerLoadBalanceMode.SLOTS
+                            ? LocationPreferenceSlotSelectionStrategy.createEvenlySpreadOut()
+                            : LocationPreferenceSlotSelectionStrategy.createDefault();
+        }
 
         final boolean isLocalRecoveryEnabled =
                 configuration.get(StateRecoveryOptions.LOCAL_RECOVERY);


### PR DESCRIPTION
## Summary
- add configuration `jobmanager.scheduler.region-aware`
- implement per-subtask `RegionSlotSharingStrategy`
- add `RegionPackingSlotSelectionStrategy` to concentrate slots on few TaskManagers
- use region-aware slot selection when the option is set

## Testing
- `mvn -q -pl flink-runtime -am -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6870e420e7388321921c8b23329c56d0